### PR TITLE
Add EAN to audio items

### DIFF
--- a/controllers/audioController.js
+++ b/controllers/audioController.js
@@ -22,9 +22,12 @@ const getAllAudio = () => {
 }
 
 const createAudio = (data) => {
-  let { title, composer, description, count } = data.body;
-  if (!title || !composer || !description || !count) {
-    return { status: 422, data: "title, composer, description and count must be set" };
+  let { title, composer, description, count, ean } = data.body;
+  if (!title || !composer || !description || !count || !ean) {
+    return { status: 422, data: "title, composer, description, count and ean must be set" };
+  }
+  if (!/^\d{13}$/.test(ean)) {
+    return { status: 422, data: "ean must be a 13 digit number" };
   }
   try {
     let filename = '';
@@ -43,7 +46,8 @@ const createAudio = (data) => {
       composer: composer,
       pic: filename,
       description: description,
-      count: count
+      count: count,
+      ean: ean
     }
     audios.push(audio);
     fs.writeFileSync('models/audio.json', JSON.stringify(audios, null, 2));
@@ -66,7 +70,7 @@ const readAudio = (id) => {
 const updateAudio = (id, data) => {
   let audioIndex = audios.findIndex(p => p.id === parseInt(id));
 
-  let { title, composer, description, count } = data.body;
+  let { title, composer, description, count, ean } = data.body;
 
   if (audioIndex != -1) {
     let filename = audios[audioIndex].pic;
@@ -79,6 +83,12 @@ const updateAudio = (id, data) => {
     if (composer != undefined) { audios[audioIndex].composer = composer; }
     if (description != undefined) { audios[audioIndex].description = description; }
     if (count != undefined) { audios[audioIndex].count = count; }
+    if (ean != undefined) {
+      if (!/^\d{13}$/.test(ean)) {
+        return { status: 422, data: "ean must be a 13 digit number" };
+      }
+      audios[audioIndex].ean = ean;
+    }
 
     fs.writeFileSync('models/audio.json', JSON.stringify(audios, null, 2));
     return { status: 200, data: audios[audioIndex] };

--- a/models/audio.json
+++ b/models/audio.json
@@ -5,7 +5,8 @@
     "composer": "Julius Kramer",
     "pic": "",
     "description": "Ein orchestraler Streifzug durch die Welt von HTML, CSS und JavaScript.",
-    "count": 5
+    "count": 5,
+    "ean": "9780000000000"
   },
   {
     "id": 1,
@@ -13,7 +14,8 @@
     "composer": "Lina Wolff",
     "pic": "",
     "description": "Eine klangvolle Komposition über Event Loops und Promises.",
-    "count": 4
+    "count": 4,
+    "ean": "9780000000001"
   },
   {
     "id": 2,
@@ -21,7 +23,8 @@
     "composer": "Finn Schneider",
     "pic": "",
     "description": "Musikalische Muster inspiriert von Flexbox, Grid und Media Queries.",
-    "count": 6
+    "count": 6,
+    "ean": "9780000000002"
   },
   {
     "id": 3,
@@ -29,7 +32,8 @@
     "composer": "Sophie Lang",
     "pic": "",
     "description": "Eine emotionale Klangreise durch Komponenten, States und Lifecycle-Methoden.",
-    "count": 3
+    "count": 3,
+    "ean": "9780000000003"
   },
   {
     "id": 4,
@@ -37,7 +41,8 @@
     "composer": "Ben Tiller",
     "pic": "",
     "description": "Ein musikalisches Werk über Branches, Commits und Merge-Konflikte.",
-    "count": 5
+    "count": 5,
+    "ean": "9780000000004"
   },
   {
     "id": 5,
@@ -45,7 +50,8 @@
     "composer": "Mara Beck",
     "pic": "",
     "description": "Ein Ambient-Stück inspiriert von Routing, Middleware und APIs.",
-    "count": 4
+    "count": 4,
+    "ean": "9780000000005"
   },
   {
     "id": 6,
@@ -53,7 +59,8 @@
     "composer": "Niklas Stern",
     "pic": "",
     "description": "Eine Suite über die Manipulation der digitalen Welt – dynamisch und interaktiv.",
-    "count": 5
+    "count": 5,
+    "ean": "9780000000006"
   },
   {
     "id": 7,
@@ -61,7 +68,8 @@
     "composer": "Elisa Gruber",
     "pic": "",
     "description": "Elektronische Klangflächen, die die Leistung und Tiefe von WebAssembly feiern.",
-    "count": 2
+    "count": 2,
+    "ean": "9780000000007"
   },
   {
     "id": 8,
@@ -69,7 +77,8 @@
     "composer": "Tobias Mahler",
     "pic": "",
     "description": "Eine minimalistische Klangstudie über Fehler, Umwege und unerwartete Lösungen.",
-    "count": 6
+    "count": 6,
+    "ean": "9780000000008"
   },
   {
     "id": 9,
@@ -77,7 +86,8 @@
     "composer": "Hannah Dietrich",
     "pic": "",
     "description": "Eine kontrapunktische Komposition zwischen Frontend und Backend.",
-    "count": 3
+    "count": 3,
+    "ean": "9780000000009"
   },
   {
     "id": 10,
@@ -85,6 +95,7 @@
     "composer": "Julius Kramer",
     "pic": "",
     "description": "Ein orchestraler Streifzug durch die Welt von HTML, CSS und JavaScript.",
-    "count": 8
+    "count": 8,
+    "ean": "9780000000010"
   }
 ]

--- a/routes/audio.js
+++ b/routes/audio.js
@@ -9,6 +9,7 @@
 *         - composer
 *         - description
 *         - count
+*         - ean
 *       properties:
 *         id:
 *           type: integer
@@ -22,9 +23,12 @@
 *         description:
 *           type: string
 *           description: A brief description of the audio
-*         count: 
+*         count:
 *           type: integer
 *           description: The number of copies available
+*         ean:
+*           type: string
+*           description: The 13 digit EAN number
 *         pic:
 *           type: file 
 *           description: The cover image of the audio
@@ -33,12 +37,14 @@
 *         composer: "Julius Kramer"
 *         description: "Ein orchestraler Streifzug durch die Welt von HTML, CSS und JavaScript."
 *         count: 5
+*         ean: "9780000000000"
 *     Audio:
 *       allOf:
 *         - $ref: '#/components/schemas/CreateAudio'
 *         - example:
 *             id: 0
 *             pic: "/uploads/audio-cover.jpg"
+*             ean: "9780000000000"
 */
 /** 
 * @swagger
@@ -80,7 +86,7 @@
 *             schema:
 *               $ref: '#/components/schemas/Audio'
 *       422:
-*         description: Validation error, title, composer, description and count must be set
+*         description: Validation error, title, composer, description, count and ean must be set
 *       500:
 *         description: Server error
 *
@@ -130,7 +136,7 @@
 *             schema:
 *               $ref: '#/components/schemas/Audio'
 *       422:
-*         description: Validation error, title, composer, description and count must be set
+*         description: Validation error, title, composer, description, count and ean must be set
 *       500:
 *         description: Server error
 *   delete:


### PR DESCRIPTION
## Summary
- extend audio controller to handle `ean`
- document `ean` field in Swagger docs
- add EAN numbers to `audio.json`

## Testing
- `npm test` *(fails: Missing script & no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6858fe5bb2b8832c817e4e62edab87b4