### PR TITLE
Implement search and borrow limits

### DIFF
--- a/controllers/booksController.js
+++ b/controllers/booksController.js
@@ -21,9 +21,12 @@ const getAllBooks = () => {
 }
 
 const createBook = (data) => {
-  let { title, author, description, count } = data.body;
-  if (!title || !author || !description || !count) {
-    return { status: 422, data: "title, author, description and count must be set" };
+  let { title, author, description, count, ean } = data.body;
+  if (!title || !author || !description || !count || !ean) {
+    return { status: 422, data: "title, author, description, count and ean must be set" };
+  }
+  if (!/^\d{13}$/.test(String(ean))) {
+    return { status: 422, data: "ean must be a 13 digit number" };
   }
   try {
     let filename = '';
@@ -42,7 +45,8 @@ const createBook = (data) => {
       author: author,
       pic: filename,
       description: description,
-      count: count
+      count: count,
+      ean: String(ean)
     }
     books.push(book);
     fs.writeFileSync('models/books.json', JSON.stringify(books, null, 2));
@@ -61,11 +65,19 @@ const readBook = (id) => {
   }
 }
 
+const findBooksByAuthor = (author) => {
+  if (!author) {
+    return { status: 422, data: "author must be set" };
+  }
+  const result = books.filter(b => b.author && b.author.toLowerCase().includes(String(author).toLowerCase()));
+  return { status: 200, data: result };
+}
+
 
 const updateBook = (id, data) => {
   let bookIndex = books.findIndex(p => p.id === parseInt(id));
 
-  let { title, author, description, count } = data.body;
+  let { title, author, description, count, ean } = data.body;
 
   if (bookIndex != -1) {
     let filename = books[bookIndex].pic;
@@ -78,6 +90,12 @@ const updateBook = (id, data) => {
     if (author != undefined) { books[bookIndex].author = author; }
     if (description != undefined) { books[bookIndex].description = description; }
     if (count != undefined) { books[bookIndex].count = count; }
+    if (ean != undefined) {
+      if (!/^\d{13}$/.test(String(ean))) {
+        return { status: 422, data: "ean must be a 13 digit number" };
+      }
+      books[bookIndex].ean = String(ean);
+    }
 
     fs.writeFileSync('models/books.json', JSON.stringify(books, null, 2));
     return { status: 200, data: books[bookIndex] };
@@ -101,5 +119,6 @@ module.exports = {
   createBook,
   readBook,
   updateBook,
-  deleteBook
+  deleteBook,
+  findBooksByAuthor
 }

--- a/controllers/borrowsController.js
+++ b/controllers/borrowsController.js
@@ -72,6 +72,11 @@ const createBorrow = (bor) => {
         return { status: check.status, data: check.data };
     }
 
+    const activeCount = borrows.filter(b => b.userid === parseInt(userid) && b.articleType === articleType && Date.parse(b.end) >= Date.now()).length;
+    if (activeCount >= 3) {
+        return { status: 422, data: "borrow limit for this article type reached" };
+    }
+
     let newId = borrows.length ? borrows[borrows.length - 1].id + 1 : 0;
     if (data.id) {
         newId = parseInt(data.id)
@@ -110,6 +115,11 @@ const updateBorrow = (id, bor) => {
     let check = checkBorrow(bor);
     if (check.status !== 200) {
         return { status: check.status, data: check.data };
+    }
+
+    const activeCount = borrows.filter(b => b.userid === parseInt(userid) && b.articleType === articleType && Date.parse(b.end) >= Date.now() && b.id !== parseInt(id)).length;
+    if (activeCount >= 3) {
+        return { status: 422, data: "borrow limit for this article type reached" };
     }
 
     if (borrowIndex != -1) {

--- a/routes/books.js
+++ b/routes/books.js
@@ -169,6 +169,12 @@ router.route("/")
     res.status(response.status).json(response.data);
   })
 
+router.route("/author/:author")
+  .get((req, res, next) => {
+    let response = booksController.findBooksByAuthor(req.params.author);
+    res.status(response.status).json(response.data);
+  })
+
 router.route("/:id")
   .get((req, res, next) => {
     let response = booksController.readBook(req.params.id, req.body);

--- a/routes/borrow.js
+++ b/routes/borrow.js
@@ -173,6 +173,20 @@ router.route("/")
     res.status(response.status).json(response.data);
   })
 
+router.get('/overdue/:year/:month/:day', (req, res, next) => {
+  const { year, month, day } = req.params;
+  const date = new Date(year, month - 1, day).toISOString().split('T')[0];
+  let response = borrowController.findOverdueAfterDate(date);
+  res.status(response.status).json(response.data);
+});
+
+router.get('/overdue/:year/:month', (req, res, next) => {
+  const { year, month } = req.params;
+  const date = new Date(year, month - 1, 1).toISOString().split('T')[0];
+  let response = borrowController.findOverdueAfterDate(date);
+  res.status(response.status).json(response.data);
+});
+
 router.route("/:id")
   .get((req, res, next) => {
     let response = borrowController.readBorrow(req.params.id, req.body);


### PR DESCRIPTION
## Summary
- add EAN handling and author search in books controller
- expose `/books/author/:author` route
- enforce per-type borrow limit and expose overdue queries

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6859570c0f4c832caf7cf123d4fc60de